### PR TITLE
Added tutorial link for SNES Classic autosplitter.

### DIFF
--- a/docs/Tutorials.md
+++ b/docs/Tutorials.md
@@ -1,3 +1,10 @@
 # Tutorials
 
-This is a page listing various tutorial for QUsb2Snes and software that use it to do various kind of thing.
+This is a page listing various tutorials for QUsb2Snes and software that use it to do various kinds of things.
+
+## Autosplitter
+
+A video tutorial detailing how to use Qusb2Snes and LiveSplit together in order to get an autosplitter working with an SNES Classic.
+https://www.youtube.com/watch?v=AUSSGh30dgA 
+
+More tutorials to come!


### PR DESCRIPTION
Added link and description to a video tutorial for using Qusb2Snes to get an autosplitter to work with an SNES Classic.